### PR TITLE
typo in channel_labels

### DIFF
--- a/pykilosort/postprocess.py
+++ b/pykilosort/postprocess.py
@@ -1477,7 +1477,7 @@ def rezToPhy(ctx, dat_path=None, output_dir=None):
 
         _save('channel_map', chanMap0ind)
         _save('channel_positions', np.c_[xcoords, ycoords], np.float32)
-        _save('channel_labels', probe.channel_labels, np.int8)
+        _save('channel_labels', probe.channels_labels, np.int8)
         if shanks is not None:
             _save('channel_shanks', shanks, np.int8)
 


### PR DESCRIPTION
Hi, there is a typo where the channel labels is written probe.channels_labels in main.py line 95, but is probe.channel_labels in postprocess.py in rezToPhy function line 1480, causing an error