### PR TITLE
Clarify paths logged by `run_spike_sorting_ibl`

### DIFF
--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -90,8 +90,9 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         params = ibl_pykilosort_params(bin_file)
     try:
         _logger.info(f"Starting Pykilosort version {__version__}")
-        _logger.info(f"Scratch dir {ks_output_dir}")
-        _logger.info(f"Output dir {bin_file.parent}")
++       _logger.info(f"Scratch dir {scratch_dir}")
++       _logger.info(f"Output dir {ks_output_dir}")
++       _logger.info(f"Data dir {bin_file.parent")
         _logger.info(f"Log file {log_file}")
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 

--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -92,7 +92,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         _logger.info(f"Starting Pykilosort version {__version__}")
 +       _logger.info(f"Scratch dir {scratch_dir}")
 +       _logger.info(f"Output dir {ks_output_dir}")
-+       _logger.info(f"Data dir {bin_file.parent")
++       _logger.info(f"Data dir {bin_file.parent}")
         _logger.info(f"Log file {log_file}")
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 


### PR DESCRIPTION
The output dir seems to be logged as the scratch dir while the `bin_file`'s directory is shown as the output dir. Adjusted to clarify