### PR TITLE
Small patches: v1.4.3

### DIFF
--- a/examples/integration_100s.py
+++ b/examples/integration_100s.py
@@ -6,7 +6,7 @@ import pykilosort
 from pykilosort.ibl import run_spike_sorting_ibl, ibl_pykilosort_params, download_test_data
 
 INTEGRATION_DATA_PATH = Path("/datadisk/Data/neuropixel/spike_sorting/integration_test")
-# INTEGRATION_DATA_PATH = Path("/mnt/s0/spikesorting/integration_tests")
+# INTEGRATION_DATA_PATH = Path("/mnt/s1/spikesorting/integration_tests")
 
 SCRATCH_DIR = Path.home().joinpath("scratch", 'pykilosort')
 shutil.rmtree(SCRATCH_DIR, ignore_errors=True)

--- a/pykilosort/__init__.py
+++ b/pykilosort/__init__.py
@@ -13,7 +13,7 @@ from .main import run, run_export, run_spikesort, run_preprocess
 from .io.probes import np1_probe, np2_probe, np2_4shank_probe
 
 
-__version__ = 'ibl_1.4.2'
+__version__ = '1.4.3'
 
 # Set a null handler on the root logger
 logger = logging.getLogger(__name__)

--- a/pykilosort/__init__.py
+++ b/pykilosort/__init__.py
@@ -15,6 +15,7 @@ from .io.probes import np1_probe, np2_probe, np2_4shank_probe
 
 __version__ = '1.4.3'
 
+
 # Set a null handler on the root logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/pykilosort/cluster.py
+++ b/pykilosort/cluster.py
@@ -357,7 +357,7 @@ def mexClustering2(Params, uproj, W, mu, call, iMatch, iC):
     d_mu = cp.asarray(mu, dtype=np.float32, order='F')
     d_call = cp.asarray(call, dtype=np.int32, order='F')
     d_iC = cp.asarray(iC, dtype=np.int32, order='F')
-    d_iMatch = cp.asarray(iMatch, dtype=np.bool, order='F')
+    d_iMatch = cp.asarray(iMatch, dtype=bool, order='F')
 
     d_dWU = cp.zeros((NrankPC * Nchan, Nfilters), dtype=np.float32, order='F')
     d_cmax = cp.zeros((Nspikes, Nfilters), dtype=np.float32, order='F')
@@ -398,7 +398,7 @@ def mexDistances2(Params, Ws, W, iMatch, iC, Wh, mus, mu):
 
     d_Ws = cp.asarray(Ws, dtype=np.float32, order='F')
     d_W = cp.asarray(W, dtype=np.float32, order='F')
-    d_iMatch = cp.asarray(iMatch, dtype=np.bool, order='F')
+    d_iMatch = cp.asarray(iMatch, dtype=bool, order='F')
     d_iC = cp.asarray(iC, dtype=np.int32, order='F')
     d_Wh = cp.asarray(Wh, dtype=np.int32, order='F')
     d_mu = cp.asarray(mu, dtype=np.float32, order='F')

--- a/pykilosort/datashift2.py
+++ b/pykilosort/datashift2.py
@@ -14,6 +14,9 @@ from .utils import get_cuda, Bunch
 
 logger = logging.getLogger(__name__)
 
+print("cp paths")
+print(cp.__path__)
+print(cp.__file__)
 
 def getClosestChannels2(ycup, xcup, yc, xc, NchanClosest):
     # this function outputs the closest channels to each channel,

--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -90,9 +90,9 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         params = ibl_pykilosort_params(bin_file)
     try:
         _logger.info(f"Starting Pykilosort version {__version__}")
-+       _logger.info(f"Scratch dir {scratch_dir}")
-+       _logger.info(f"Output dir {ks_output_dir}")
-+       _logger.info(f"Data dir {bin_file.parent}")
+        _logger.info(f"Scratch dir {scratch_dir}")
+        _logger.info(f"Output dir {ks_output_dir}")
+        _logger.info(f"Data dir {bin_file.parent}")
         _logger.info(f"Log file {log_file}")
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 

--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -90,8 +90,9 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
         params = ibl_pykilosort_params(bin_file)
     try:
         _logger.info(f"Starting Pykilosort version {__version__}")
-        _logger.info(f"Scratch dir {ks_output_dir}")
-        _logger.info(f"Output dir {bin_file.parent}")
++       _logger.info(f"Scratch dir {scratch_dir}")
++       _logger.info(f"Output dir {ks_output_dir}")
++       _logger.info(f"Data dir {bin_file.parent}")
         _logger.info(f"Log file {log_file}")
         _logger.info(f"Loaded probe geometry for NP{params['probe']['neuropixel_version']}")
 

--- a/pykilosort/learn.py
+++ b/pykilosort/learn.py
@@ -400,7 +400,7 @@ def mexMPnu8(Params, dataRAW, U, W, mu, iC, iW, UtU, iList, wPCA, params):
     d_mu = cp.asarray(mu, dtype=np.float32, order="F")
     d_iC = cp.asarray(iC, dtype=np.int32, order="F")
     d_iW = cp.asarray(iW, dtype=np.int32, order="F")
-    d_UtU = cp.asarray(UtU, dtype=np.bool, order="F")
+    d_UtU = cp.asarray(UtU, dtype=bool, order="F")
     d_iList = cp.asarray(iList, dtype=np.int32, order="F")
     d_wPCA = cp.asarray(wPCA, dtype=np.float32, order="F")
 

--- a/pykilosort/postprocess.py
+++ b/pykilosort/postprocess.py
@@ -1241,7 +1241,7 @@ def checkClusters(ctx):
 
     ir = ctx.intermediate
     n_templates = ir.Wphy.shape[1]
-    ids = cp.asnumpy(np.unique(ir.st3[:, 1]).astype(np.int))
+    ids = cp.asnumpy(np.unique(ir.st3[:, 1]).astype(int))
     # Check if the max cluster id is equal to the number of cluster ids assigned to spikes.
     if n_templates != len(ids):  # see which cluster ids are missing
         good_units_mask = np.isin(np.arange(n_templates), ids)


### PR DESCRIPTION
#### `np` aliases deprecated

Running spike sorting with more recent environments throws errors about `np` having no attribute `bool`

This was just an alias for `bool` and is now deprecated as of Numpy 1.20.0:

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

This PR just drops in `bool` where `np.bool` was

Same for `np.int`

#### Slight logging improvement

This PR also contains the changes from #11 for logging:

> The output dir seems to be logged as the scratch dir while the bin_file's directory is shown as the output dir. Adjusted to clarify

#### Integration test path

Lastly, update the integration test paths as s0 and s1 mounts have been switched on Parede

#### Version name

The latest version of `setuptools` disallows version names like `ibl_1.4.2`. The new version has been bumped and renamed to just `1.4.3`