### PR TITLE
Channel detection fixes

### DIFF
--- a/pykilosort/__init__.py
+++ b/pykilosort/__init__.py
@@ -13,7 +13,7 @@ from .main import run, run_export, run_spikesort, run_preprocess
 from .io.probes import np1_probe, np2_probe, np2_4shank_probe
 
 
-__version__ = '1.4.6'
+__version__ = '1.4.7'
 
 
 # Set a null handler on the root logger

--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -119,7 +119,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
 def ibl_pykilosort_params(bin_file):
     params = KilosortParams()
     params.preprocessing_function = 'destriping'
-    params.detect_channels_method = 'raw_correlations'
+    params.channel_detection_method = 'raw_correlations'
     params.probe = probe_geometry(bin_file)
     params.minFR = 0
     params.minfr_goodchannels = 0

--- a/pykilosort/ibl.py
+++ b/pykilosort/ibl.py
@@ -119,6 +119,7 @@ def run_spike_sorting_ibl(bin_file, scratch_dir=None, delete=True,
 def ibl_pykilosort_params(bin_file):
     params = KilosortParams()
     params.preprocessing_function = 'destriping'
+    params.detect_channels_method = 'raw_correlations'
     params.probe = probe_geometry(bin_file)
     params.minFR = 0
     params.minfr_goodchannels = 0

--- a/pykilosort/main.py
+++ b/pykilosort/main.py
@@ -92,12 +92,13 @@ def run(
     probe.Nchan = len(probe.chanMap)
     # keep all channels but still output a quality control metric. Also the covariance matrix will be stabilized
     # by taking into account those noisy channels
-    probe.good_channels = get_good_channels(
-        raw_data, params, probe, method='kilosort', return_labels=True)
+
+    # channel detection method is either "raw_correlations" or "kilosort" based on the "detect_channels_method"
+    # entry in params
+    probe.good_channels, probe.channels_labels = get_good_channels(
+        raw_data, params, probe, return_labels=True)
     assert probe.Nchan > 0
     
-    probe.channels_labels = (~probe.good_channels).astype(int)
-
     # upper bound on the number of templates we can have
     params.Nfilt = params.nfilt_factor * probe.Nchan
 

--- a/pykilosort/main.py
+++ b/pykilosort/main.py
@@ -93,8 +93,8 @@ def run(
     # keep all channels but still output a quality control metric. Also the covariance matrix will be stabilized
     # by taking into account those noisy channels
 
-    # channel detection method is either "raw_correlations" or "kilosort" based on the "detect_channels_method"
-    # entry in params
+    # channel detection method is either "raw_correlations" or "kilosort" based on the
+    # "channel_detection_method" field in params
     probe.good_channels, probe.channels_labels = get_good_channels(
         raw_data, params, probe, return_labels=True)
     assert probe.Nchan > 0

--- a/pykilosort/main.py
+++ b/pykilosort/main.py
@@ -92,9 +92,11 @@ def run(
     probe.Nchan = len(probe.chanMap)
     # keep all channels but still output a quality control metric. Also the covariance matrix will be stabilized
     # by taking into account those noisy channels
-    probe.good_channels, probe.channels_labels = get_good_channels(
-        raw_data, params, probe, method='raw_correlations', return_labels=True)
+    probe.good_channels = get_good_channels(
+        raw_data, params, probe, method='kilosort', return_labels=True)
     assert probe.Nchan > 0
+    
+    probe.channels_labels = (~probe.good_channels).astype(int)
 
     # upper bound on the number of templates we can have
     params.Nfilt = params.nfilt_factor * probe.Nchan

--- a/pykilosort/params.py
+++ b/pykilosort/params.py
@@ -71,6 +71,9 @@ class KilosortParams(BaseModel):
     preprocessing_function: str = Field('kilosort2', description='pre-processing function used choices'
                                                                  'are "kilosort2" or "destriping"')
     
+    channel_detection_method: str = Field('kilosort', description = 'channel detection methods choices'
+                                                                     'are "raw_correlations" or "kilosort"')
+    
     save_drift_spike_detections: bool = Field(False, description='save detected spikes in drift correction')
     
     perform_drift_registration: bool = Field(True, description='Estimate electrode drift and apply registration')

--- a/pykilosort/preprocess.py
+++ b/pykilosort/preprocess.py
@@ -308,7 +308,7 @@ def get_good_channels_raw_correlations(raw_data, params, probe, t0s=None, return
         return channel_labels == 0
 
 
-def get_good_channels_kilosort(raw_data=None, probe=None, params=None):
+def get_good_channels_kilosort(raw_data=None, params=None, probe=None):
     """
     of the channels indicated by the user as good (chanMap)
     further subset those that have a mean firing rate above a certain value

--- a/pykilosort/preprocess.py
+++ b/pykilosort/preprocess.py
@@ -275,13 +275,17 @@ def get_whitening_matrix(raw_data=None, probe=None, params=None, qc_path=None):
     return Wrot
 
 
-def get_good_channels(raw_data, probe, params, **kwargs):
-    if "detect_channels_method" in params:
-        method = params["detect_channels_method"]
-    if method == 'raw_correlations':
-        return get_good_channels_raw_correlations(raw_data, probe, params, **kwargs)
+def get_good_channels(raw_data, params, probe, **kwargs):
+    """
+    Wrapper for two choices of channel detection: 'raw_correlations' and
+    'kilosort'. Passes kwargs through to 
+    individual methods.
+    """
+    method = params.channel_detection_method
+    if method == "raw_correlations":
+        return get_good_channels_raw_correlations(raw_data, params, probe, **kwargs)
     else:
-        return get_good_channels_kilosort(raw_data, probe, params)
+        return get_good_channels_kilosort(raw_data, params, probe, **kwargs)
 
 
 def get_good_channels_raw_correlations(raw_data, params, probe, t0s=None, return_labels=False):
@@ -310,7 +314,7 @@ def get_good_channels_raw_correlations(raw_data, params, probe, t0s=None, return
         return channel_labels == 0
 
 
-def get_good_channels_kilosort(raw_data=None, params=None, probe=None, return_labels=False):
+def get_good_channels_kilosort(raw_data, params, probe, return_labels=False):
     """
     Of the channels indicated by the user as good (chanMap), 
     further subset those that have a mean firing rate above a certain value


### PR DESCRIPTION
Makes the `"kilosort"` channel detection method usable (addressing bug pointed out in #19) via `params` entry. Now to use IBL channel detection, set `params["detect_channels_method"] = "raw_correlations"`, otherwise will default to `"kilosort"`